### PR TITLE
Counter implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Condition Checker 
 # 🛠️ WIP 🛠️
-An application to check the weather conditions of Mersey Rowing Club at the 6am and 6pm (for morning and evening sessions) to see if boats can go ahead. 
+An application to check the weather conditions of Mersey Rowing Club at 6am and 6pm (for morning and evening sessions) to see if boats can go ahead. 
 
 ## How to run
 - Install the Env file plugin https://plugins.jetbrains.com/plugin/7861-envfile 
@@ -15,6 +15,10 @@ Prerequisites:
 Instructions:
 - Run `docker-compose up -d ` (this starts the wiremock container)
 - Run the maven unit tests _(right click on `java.com.mersey.rowing.club.condition_checker` -> run all tests)_
+
+### Counter.txt File
+The counter.txt file is essential for keeping an eye on the number of API calls made per day.  
+It contains the current date which is updated automatically when the API is called, and a counter, which is also updated and refreshed each day automatically, to keep track of the number of API calls made on the current date.
 
 # Application Logic and Reasoning
 Currently, we are working from a [Miro](https://miro.com/app/board/uXjVPMF8Djc=/?moveToWidget=3458764584603444169&cot=14) (_currently private, please request access if necessary_) page, designed by Adelaide Baron. Additionally, work is being prioritised through the GitHub Project associated with this repository. 

--- a/condition-checker/src/main/java/com/mersey/rowing/club/condition_checker/controller/openweather/OpenWeatherApiClient.java
+++ b/condition-checker/src/main/java/com/mersey/rowing/club/condition_checker/controller/openweather/OpenWeatherApiClient.java
@@ -55,15 +55,29 @@ public class OpenWeatherApiClient {
 
   public String checkDateAndAddCounter() {
       BufferedReader bufferedReader = null;
+      String currentDate = "12/12/1970";
+      Integer counter = 1;
       try {
           bufferedReader = new BufferedReader(new FileReader("C:\\Users\\Sam\\Documents\\Code\\condition-checker\\condition-checker\\src\\main\\resources\\counter.txt"));
-        // Skipping first line & grabbing date in file
+        // Checking to see if file is empty or not
+        String firstLine = bufferedReader.readLine();
+        if (firstLine == null) {
+          openFileAndUpdateCounter(currentDate, counter);
+          log.info("counter.txt was empty! Calls remaining may not be accurate!");
+          // Closing reader to reset to beginning of counter.txt
+          bufferedReader.close();
+        }
+
+        // Reinitialising the buffered reader to start from the top of counter.txt
+        bufferedReader = new BufferedReader(new FileReader("C:\\Users\\Sam\\Documents\\Code\\condition-checker\\condition-checker\\src\\main\\resources\\counter.txt"));
+
+        // Skipping first line and grabbing currentDate
         bufferedReader.readLine();
-        String currentDate = bufferedReader.readLine();
+        currentDate = bufferedReader.readLine();
 
         // Skipping third line and grabbing current number of API calls
         bufferedReader.readLine();
-        Integer counter = Integer.valueOf(bufferedReader.readLine());
+        counter = Integer.valueOf(bufferedReader.readLine());
         bufferedReader.close();
 
         // Logic to update counter.txt
@@ -74,9 +88,14 @@ public class OpenWeatherApiClient {
           counter = 1;
         }
 
-        if (counter > 900) {
+        if (counter > 900 && counter < 1000) {
           System.out.println("There are less than 100 calls left for today! Please use sparingly.");
             log.warn("There are only {} calls left", 1000 - counter);
+        } else if (counter > 1000) {
+          System.out.println("There are no calls left for today's date.");
+          log.warn("There are no calls left for today");
+        } else {
+          log.info("There are a total of: {} calls left for today", 1000 - counter);
         }
 
         // Opening and updating counter.txt

--- a/condition-checker/src/main/java/com/mersey/rowing/club/condition_checker/controller/openweather/OpenWeatherApiClient.java
+++ b/condition-checker/src/main/java/com/mersey/rowing/club/condition_checker/controller/openweather/OpenWeatherApiClient.java
@@ -74,6 +74,11 @@ public class OpenWeatherApiClient {
           counter = 1;
         }
 
+        if (counter > 900) {
+          System.out.println("There are less than 100 calls left for today! Please use sparingly.");
+          log.warn("There are only " + (1000 - counter) + " calls left");
+        }
+
         // Opening and updating counter.txt
         openFileAndUpdateCounter(currentDate, counter);
 

--- a/condition-checker/src/main/java/com/mersey/rowing/club/condition_checker/controller/openweather/OpenWeatherApiClient.java
+++ b/condition-checker/src/main/java/com/mersey/rowing/club/condition_checker/controller/openweather/OpenWeatherApiClient.java
@@ -11,11 +11,18 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClientResponseException;
 import org.springframework.web.client.RestTemplate;
 
+import java.io.*;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.time.format.DateTimeFormatter;
+
 @Component
 @Slf4j
 public class OpenWeatherApiClient {
 
   RestTemplate restTemplate = new RestTemplate();
+  private static final DateTimeFormatter dtfMinusHours = DateTimeFormatter.ofPattern("dd/MM/yyyy");
+
 
   @Autowired
   private DateUtil dateUtil;
@@ -44,5 +51,38 @@ public class OpenWeatherApiClient {
       log.error("Unexpected error: " + e.getMessage());
       throw e;
     }
+  }
+
+  public String checkDateAndAddCounter() throws IOException {
+    BufferedReader bufferedReader = new BufferedReader(new FileReader("src/main/resources/counter.txt"));
+
+    // Skipping first line & grabbing date in file
+    bufferedReader.readLine();
+    String currentDate = bufferedReader.readLine();
+
+    // Skipping third line and grabbing current number of API calls
+    bufferedReader.readLine();
+    Integer counter = Integer.valueOf(bufferedReader.readLine());
+    bufferedReader.close();
+
+    // Logic to update counter.txt
+    if (dateUtil.getCurrentDate().toString().equals(currentDate)) {
+      counter++;
+    } else {
+      currentDate = dtfMinusHours.format(dateUtil.getCurrentDate());
+      counter = 1;
+    }
+
+    // Opening and updating counter.txt
+    BufferedWriter bufferedWriter = new BufferedWriter(new FileWriter("src/main/resources/counter.txt"));
+
+    bufferedWriter.write("Current Date:\n");
+    bufferedWriter.write(currentDate + "\n");
+
+    bufferedWriter.write("No. of API calls since above date:\n");
+    bufferedWriter.write(String.valueOf(counter));
+    bufferedWriter.close();
+
+    return currentDate;
   }
 }

--- a/condition-checker/src/main/java/com/mersey/rowing/club/condition_checker/controller/openweather/OpenWeatherApiClient.java
+++ b/condition-checker/src/main/java/com/mersey/rowing/club/condition_checker/controller/openweather/OpenWeatherApiClient.java
@@ -56,7 +56,7 @@ public class OpenWeatherApiClient {
 
         BufferedReader bufferedReader = null;
         String currentDate = "12/12/1970";
-        Integer counter = 1;
+        int counter = 1;
 
         // Checking if counter.txt exists
         File file = new File("C:\\Users\\Sam\\Documents\\Code\\condition-checker\\condition-checker\\src\\main\\resources\\counter.txt");
@@ -64,11 +64,12 @@ public class OpenWeatherApiClient {
         // If file does not exist, counter.txt is created and filled with boilerplate code
         if (!file.exists()) {
             try {
+                log.info("counter.txt was not found! Creating now.");
                 BufferedWriter bufferedWriter = new BufferedWriter(new FileWriter("C:\\Users\\Sam\\Documents\\Code\\condition-checker\\condition-checker\\src\\main\\resources\\counter.txt"));
                 bufferedWriter.write("Current Date:\n");
                 bufferedWriter.write(currentDate + "\n");
                 bufferedWriter.write("Counter:\n");
-                bufferedWriter.write(counter);
+                bufferedWriter.write(String.valueOf(counter));
                 bufferedWriter.close();
             } catch (IOException e) {
                 throw new RuntimeException(e);
@@ -94,7 +95,7 @@ public class OpenWeatherApiClient {
 
             // Skipping third line and grabbing current number of API calls
             bufferedReader.readLine();
-            counter = Integer.valueOf(bufferedReader.readLine());
+            counter = Integer.parseInt(bufferedReader.readLine());
             bufferedReader.close();
 
             // Logic to update counter.txt

--- a/condition-checker/src/main/java/com/mersey/rowing/club/condition_checker/controller/openweather/OpenWeatherApiClient.java
+++ b/condition-checker/src/main/java/com/mersey/rowing/club/condition_checker/controller/openweather/OpenWeatherApiClient.java
@@ -55,15 +55,16 @@ public class OpenWeatherApiClient {
         BufferedReader bufferedReader = null;
         String currentDate = "12/12/1970";
         int counter = 1;
+        String counterPath = System.getProperty("user.dir") + "/condition-checker/src/main/resources/counter.txt";
 
         // Checking if counter.txt exists
-        File file = new File("C:\\Users\\Sam\\Documents\\Code\\condition-checker\\condition-checker\\src\\main\\resources\\counter.txt");
+        File file = new File(counterPath);
 
         // If file does not exist, counter.txt is created and filled with boilerplate code
         if (!file.exists()) {
             try {
                 log.info("counter.txt was not found! Creating now.");
-                BufferedWriter bufferedWriter = new BufferedWriter(new FileWriter("C:\\Users\\Sam\\Documents\\Code\\condition-checker\\condition-checker\\src\\main\\resources\\counter.txt"));
+                BufferedWriter bufferedWriter = new BufferedWriter(new FileWriter(counterPath));
                 bufferedWriter.write("Current Date:\n");
                 bufferedWriter.write(currentDate + "\n");
                 bufferedWriter.write("Counter:\n");
@@ -74,7 +75,7 @@ public class OpenWeatherApiClient {
             }
         }
         try {
-            bufferedReader = new BufferedReader(new FileReader("C:\\Users\\Sam\\Documents\\Code\\condition-checker\\condition-checker\\src\\main\\resources\\counter.txt"));
+            bufferedReader = new BufferedReader(new FileReader(counterPath));
             // Checking to see if file is empty or not
             String firstLine = bufferedReader.readLine();
             if (firstLine == null) {
@@ -85,7 +86,7 @@ public class OpenWeatherApiClient {
             }
 
             // Reinitialising the buffered reader to start from the top of counter.txt
-            bufferedReader = new BufferedReader(new FileReader("C:\\Users\\Sam\\Documents\\Code\\condition-checker\\condition-checker\\src\\main\\resources\\counter.txt"));
+            bufferedReader = new BufferedReader(new FileReader(counterPath));
 
             // Skipping first line and grabbing currentDate
             bufferedReader.readLine();

--- a/condition-checker/src/main/java/com/mersey/rowing/club/condition_checker/controller/openweather/OpenWeatherApiClient.java
+++ b/condition-checker/src/main/java/com/mersey/rowing/club/condition_checker/controller/openweather/OpenWeatherApiClient.java
@@ -76,7 +76,7 @@ public class OpenWeatherApiClient {
 
         if (counter > 900) {
           System.out.println("There are less than 100 calls left for today! Please use sparingly.");
-          log.warn("There are only " + (1000 - counter) + " calls left");
+            log.warn("There are only {} calls left", 1000 - counter);
         }
 
         // Opening and updating counter.txt

--- a/condition-checker/src/main/java/com/mersey/rowing/club/condition_checker/controller/openweather/OpenWeatherApiClient.java
+++ b/condition-checker/src/main/java/com/mersey/rowing/club/condition_checker/controller/openweather/OpenWeatherApiClient.java
@@ -19,8 +19,6 @@ import java.time.format.DateTimeFormatter;
 public class OpenWeatherApiClient {
 
     RestTemplate restTemplate = new RestTemplate();
-    private static final DateTimeFormatter dtfMinusHours = DateTimeFormatter.ofPattern("dd/MM/yyyy");
-
 
     @Autowired
     private DateUtil dateUtil;
@@ -99,10 +97,10 @@ public class OpenWeatherApiClient {
             bufferedReader.close();
 
             // Logic to update counter.txt
-            if (dtfMinusHours.format(dateUtil.getCurrentDate()).equals(currentDate)) {
+            if (dateUtil.dtfMinusHours.format(dateUtil.getCurrentDate()).equals(currentDate)) {
                 counter++;
             } else {
-                currentDate = dtfMinusHours.format(dateUtil.getCurrentDate());
+                currentDate = dateUtil.dtfMinusHours.format(dateUtil.getCurrentDate());
                 counter = 1;
             }
 

--- a/condition-checker/src/main/java/com/mersey/rowing/club/condition_checker/controller/openweather/OpenWeatherApiClient.java
+++ b/condition-checker/src/main/java/com/mersey/rowing/club/condition_checker/controller/openweather/OpenWeatherApiClient.java
@@ -12,109 +12,126 @@ import org.springframework.web.client.RestClientResponseException;
 import org.springframework.web.client.RestTemplate;
 
 import java.io.*;
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
 import java.time.format.DateTimeFormatter;
 
 @Component
 @Slf4j
 public class OpenWeatherApiClient {
 
-  RestTemplate restTemplate = new RestTemplate();
-  private static final DateTimeFormatter dtfMinusHours = DateTimeFormatter.ofPattern("dd/MM/yyyy");
+    RestTemplate restTemplate = new RestTemplate();
+    private static final DateTimeFormatter dtfMinusHours = DateTimeFormatter.ofPattern("dd/MM/yyyy");
 
 
-  @Autowired private DateUtil dateUtil;
+    @Autowired
+    private DateUtil dateUtil;
 
-  @Value("${open-weather-api.key}")
-  private String apiKey;
+    @Value("${open-weather-api.key}")
+    private String apiKey;
 
-  @Value("${open-weather-api.baseUrl}")
-  private String apiBaseUrl;
+    @Value("${open-weather-api.baseUrl}")
+    private String apiBaseUrl;
 
-  @Value("${open-weather-api.endpoint}")
-  private String apiEndpoint;
+    @Value("${open-weather-api.endpoint}")
+    private String apiEndpoint;
 
-  public StatusCodeObject getOpenWeatherAPIResponse(long epoch) {
-    String url = String.format(apiBaseUrl + apiEndpoint, epoch, apiKey);
-    Class<OpenWeatherResponse> responseType = OpenWeatherResponse.class;
-    try {
-      checkDateAndAddCounter();
-      OpenWeatherResponse openWeatherResponse = restTemplate.getForObject(url, responseType);
-      log.info("Successfully retrieved and mapped response from open weather API");
-      return new StatusCodeObject(HttpStatus.OK, openWeatherResponse);
-    } catch (RestClientResponseException e) {
-      log.error("Open Weather API gave an unexpected response: {}", e.getStatusCode());
-      return new StatusCodeObject(
-          (HttpStatus) e.getStatusCode(), dateUtil.getDatetimeFromEpochSeconds(epoch));
-    } catch (Exception e) {
-      log.error("Unexpected error: " + e.getMessage());
-      throw e;
+    public StatusCodeObject getOpenWeatherAPIResponse(long epoch) {
+        String url = String.format(apiBaseUrl + apiEndpoint, epoch, apiKey);
+        Class<OpenWeatherResponse> responseType = OpenWeatherResponse.class;
+        try {
+            checkDateAndAddCounter();
+            OpenWeatherResponse openWeatherResponse = restTemplate.getForObject(url, responseType);
+            log.info("Successfully retrieved and mapped response from open weather API");
+            return new StatusCodeObject(HttpStatus.OK, openWeatherResponse);
+        } catch (RestClientResponseException e) {
+            log.error("Open Weather API gave an unexpected response: {}", e.getStatusCode());
+            return new StatusCodeObject(
+                    (HttpStatus) e.getStatusCode(), dateUtil.getDatetimeFromEpochSeconds(epoch));
+        } catch (Exception e) {
+            log.error("Unexpected error: " + e.getMessage());
+            throw e;
+        }
     }
-  }
 
-  public String checkDateAndAddCounter() {
-      BufferedReader bufferedReader = null;
-      String currentDate = "12/12/1970";
-      Integer counter = 1;
-      try {
-          bufferedReader = new BufferedReader(new FileReader("C:\\Users\\Sam\\Documents\\Code\\condition-checker\\condition-checker\\src\\main\\resources\\counter.txt"));
-        // Checking to see if file is empty or not
-        String firstLine = bufferedReader.readLine();
-        if (firstLine == null) {
-          openFileAndUpdateCounter(currentDate, counter);
-          log.info("counter.txt was empty! Calls remaining may not be accurate!");
-          // Closing reader to reset to beginning of counter.txt
-          bufferedReader.close();
+    public String checkDateAndAddCounter() {
+
+        BufferedReader bufferedReader = null;
+        String currentDate = "12/12/1970";
+        Integer counter = 1;
+
+        // Checking if counter.txt exists
+        File file = new File("C:\\Users\\Sam\\Documents\\Code\\condition-checker\\condition-checker\\src\\main\\resources\\counter.txt");
+
+        // If file does not exist, counter.txt is created and filled with boilerplate code
+        if (!file.exists()) {
+            try {
+                BufferedWriter bufferedWriter = new BufferedWriter(new FileWriter("C:\\Users\\Sam\\Documents\\Code\\condition-checker\\condition-checker\\src\\main\\resources\\counter.txt"));
+                bufferedWriter.write("Current Date:\n");
+                bufferedWriter.write(currentDate + "\n");
+                bufferedWriter.write("Counter:\n");
+                bufferedWriter.write(counter);
+                bufferedWriter.close();
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
         }
+        try {
+            bufferedReader = new BufferedReader(new FileReader("C:\\Users\\Sam\\Documents\\Code\\condition-checker\\condition-checker\\src\\main\\resources\\counter.txt"));
+            // Checking to see if file is empty or not
+            String firstLine = bufferedReader.readLine();
+            if (firstLine == null) {
+                openFileAndUpdateCounter(currentDate, counter);
+                log.info("counter.txt was empty! Calls remaining may not be accurate!");
+                // Closing reader to reset to beginning of counter.txt
+                bufferedReader.close();
+            }
 
-        // Reinitialising the buffered reader to start from the top of counter.txt
-        bufferedReader = new BufferedReader(new FileReader("C:\\Users\\Sam\\Documents\\Code\\condition-checker\\condition-checker\\src\\main\\resources\\counter.txt"));
+            // Reinitialising the buffered reader to start from the top of counter.txt
+            bufferedReader = new BufferedReader(new FileReader("C:\\Users\\Sam\\Documents\\Code\\condition-checker\\condition-checker\\src\\main\\resources\\counter.txt"));
 
-        // Skipping first line and grabbing currentDate
-        bufferedReader.readLine();
-        currentDate = bufferedReader.readLine();
+            // Skipping first line and grabbing currentDate
+            bufferedReader.readLine();
+            currentDate = bufferedReader.readLine();
 
-        // Skipping third line and grabbing current number of API calls
-        bufferedReader.readLine();
-        counter = Integer.valueOf(bufferedReader.readLine());
-        bufferedReader.close();
+            // Skipping third line and grabbing current number of API calls
+            bufferedReader.readLine();
+            counter = Integer.valueOf(bufferedReader.readLine());
+            bufferedReader.close();
 
-        // Logic to update counter.txt
-        if (dtfMinusHours.format(dateUtil.getCurrentDate()).equals(currentDate)) {
-           counter++;
-        } else {
-          currentDate = dtfMinusHours.format(dateUtil.getCurrentDate());
-          counter = 1;
+            // Logic to update counter.txt
+            if (dtfMinusHours.format(dateUtil.getCurrentDate()).equals(currentDate)) {
+                counter++;
+            } else {
+                currentDate = dtfMinusHours.format(dateUtil.getCurrentDate());
+                counter = 1;
+            }
+
+            if (counter > 900 && counter < 1000) {
+                System.out.println("There are less than 100 calls left for today! Please use sparingly.");
+                log.warn("There are only {} calls left", 1000 - counter);
+            } else if (counter > 1000) {
+                System.out.println("There are no calls left for today's date.");
+                log.warn("There are no calls left for today");
+            } else {
+                log.info("There are a total of: {} calls left for today", 1000 - counter);
+            }
+
+            // Opening and updating counter.txt
+            openFileAndUpdateCounter(currentDate, counter);
+
+            return currentDate;
+        } catch (IOException e) {
+            throw new RuntimeException(e);
         }
+    }
 
-        if (counter > 900 && counter < 1000) {
-          System.out.println("There are less than 100 calls left for today! Please use sparingly.");
-            log.warn("There are only {} calls left", 1000 - counter);
-        } else if (counter > 1000) {
-          System.out.println("There are no calls left for today's date.");
-          log.warn("There are no calls left for today");
-        } else {
-          log.info("There are a total of: {} calls left for today", 1000 - counter);
-        }
+    private static void openFileAndUpdateCounter(String currentDate, Integer counter) throws IOException {
+        BufferedWriter bufferedWriter = new BufferedWriter(new FileWriter("C:\\Users\\Sam\\Documents\\Code\\condition-checker\\condition-checker\\src\\main\\resources\\counter.txt"));
 
-        // Opening and updating counter.txt
-        openFileAndUpdateCounter(currentDate, counter);
+        bufferedWriter.write("Current Date:\n");
+        bufferedWriter.write(currentDate + "\n");
 
-        return currentDate;
-      } catch (IOException e) {
-          throw new RuntimeException(e);
-      }
-  }
-
-  private static void openFileAndUpdateCounter(String currentDate, Integer counter) throws IOException {
-    BufferedWriter bufferedWriter = new BufferedWriter(new FileWriter("C:\\Users\\Sam\\Documents\\Code\\condition-checker\\condition-checker\\src\\main\\resources\\counter.txt"));
-
-    bufferedWriter.write("Current Date:\n");
-    bufferedWriter.write(currentDate + "\n");
-
-    bufferedWriter.write("No. of API calls since above date:\n");
-    bufferedWriter.write(String.valueOf(counter));
-    bufferedWriter.close();
-  }
+        bufferedWriter.write("No. of API calls since above date:\n");
+        bufferedWriter.write(String.valueOf(counter));
+        bufferedWriter.close();
+    }
 }

--- a/condition-checker/src/main/java/com/mersey/rowing/club/condition_checker/controller/openweather/OpenWeatherApiClient.java
+++ b/condition-checker/src/main/java/com/mersey/rowing/club/condition_checker/controller/openweather/OpenWeatherApiClient.java
@@ -56,7 +56,7 @@ public class OpenWeatherApiClient {
   public String checkDateAndAddCounter() {
       BufferedReader bufferedReader = null;
       try {
-          bufferedReader = new BufferedReader(new FileReader("src/main/resources/counter.txt"));
+          bufferedReader = new BufferedReader(new FileReader("C:\\Users\\Sam\\Documents\\Code\\condition-checker\\condition-checker\\src\\main\\resources\\counter.txt"));
         // Skipping first line & grabbing date in file
         bufferedReader.readLine();
         String currentDate = bufferedReader.readLine();
@@ -67,8 +67,8 @@ public class OpenWeatherApiClient {
         bufferedReader.close();
 
         // Logic to update counter.txt
-        if (dateUtil.getCurrentDate().toString().equals(currentDate)) {
-          counter++;
+        if (dtfMinusHours.format(dateUtil.getCurrentDate()).equals(currentDate)) {
+           counter++;
         } else {
           currentDate = dtfMinusHours.format(dateUtil.getCurrentDate());
           counter = 1;
@@ -86,12 +86,10 @@ public class OpenWeatherApiClient {
       } catch (IOException e) {
           throw new RuntimeException(e);
       }
-
-
   }
 
   private static void openFileAndUpdateCounter(String currentDate, Integer counter) throws IOException {
-    BufferedWriter bufferedWriter = new BufferedWriter(new FileWriter("src/main/resources/counter.txt"));
+    BufferedWriter bufferedWriter = new BufferedWriter(new FileWriter("C:\\Users\\Sam\\Documents\\Code\\condition-checker\\condition-checker\\src\\main\\resources\\counter.txt"));
 
     bufferedWriter.write("Current Date:\n");
     bufferedWriter.write(currentDate + "\n");

--- a/condition-checker/src/main/java/com/mersey/rowing/club/condition_checker/controller/util/DateUtil.java
+++ b/condition-checker/src/main/java/com/mersey/rowing/club/condition_checker/controller/util/DateUtil.java
@@ -20,7 +20,7 @@ public class DateUtil {
   @Autowired
   private Clock clock;
 
-  private LocalDate getCurrentDate() {
+  public LocalDate getCurrentDate() {
     return LocalDate.now(clock);
   }
 
@@ -91,4 +91,5 @@ public class DateUtil {
     Instant instant = Instant.ofEpochSecond(epoch);
     LocalDateTime dateTime = LocalDateTime.ofInstant(instant, ZoneId.systemDefault());
     return dateTime.format(dtf);
-  }}
+  }
+}

--- a/condition-checker/src/main/java/com/mersey/rowing/club/condition_checker/controller/util/DateUtil.java
+++ b/condition-checker/src/main/java/com/mersey/rowing/club/condition_checker/controller/util/DateUtil.java
@@ -21,7 +21,7 @@ public class DateUtil {
 
   @Autowired private Clock clock;
 
-  private LocalDate getCurrentDate() {
+  public LocalDate getCurrentDate() {
     return LocalDate.now(clock);
   }
 

--- a/condition-checker/src/main/java/com/mersey/rowing/club/condition_checker/controller/util/DateUtil.java
+++ b/condition-checker/src/main/java/com/mersey/rowing/club/condition_checker/controller/util/DateUtil.java
@@ -16,7 +16,7 @@ public class DateUtil {
   private static final String sixEvening = "18:00";
   private static final ZoneId zoneId = ZoneId.of("Europe/London");
   private static final DateTimeFormatter dtf = DateTimeFormatter.ofPattern("dd/MM/yyyy HH:mm");
-  private static final DateTimeFormatter dtfMinusHours = DateTimeFormatter.ofPattern("dd/MM/yyyy");
+  public final DateTimeFormatter dtfMinusHours = DateTimeFormatter.ofPattern("dd/MM/yyyy");
   private static final long ONE_HOUR_EPOCH = 3600L;
 
   @Autowired private Clock clock;

--- a/condition-checker/src/main/resources/counter.txt
+++ b/condition-checker/src/main/resources/counter.txt
@@ -1,0 +1,4 @@
+Current Date:
+25/07/2024
+No. of API calls since above date:
+1

--- a/condition-checker/src/main/resources/counter.txt
+++ b/condition-checker/src/main/resources/counter.txt
@@ -1,4 +1,4 @@
 Current Date:
-25/07/2024
+13/08/2024
 No. of API calls since above date:
 1

--- a/condition-checker/src/test/java/com/mersey/rowing/club/condition_checker/applicationTests/controller/openWeather/OpenWeatherApiClientTests.java
+++ b/condition-checker/src/test/java/com/mersey/rowing/club/condition_checker/applicationTests/controller/openWeather/OpenWeatherApiClientTests.java
@@ -27,8 +27,7 @@ public class OpenWeatherApiClientTests extends WireMockSpecificDtBaseTests {
   private ObjectMapper objectMapper = new ObjectMapper();
 
   @Test
-  void getOpenWeatherAPIResponse_apiGivesExpectedResponse_mapsToOWResponse_withCorrectDT()
-      throws JsonProcessingException, JSONException {
+  void getOpenWeatherAPIResponse_apiGivesExpectedResponse_mapsToOWResponse_withCorrectDT() throws JSONException, JsonProcessingException {
     int testDateTime = 1720626363;
 
     setupWiremockMappingForDt(testDateTime);
@@ -50,14 +49,5 @@ public class OpenWeatherApiClientTests extends WireMockSpecificDtBaseTests {
 
     assertThat(statusCodeObject)
         .isEqualTo(openWeatherApiClient.getOpenWeatherAPIResponse(1720626363L));
-  }
-
-  //Placeholder Test
-  @Test
-  void checkDateAndAddCounter() throws IOException {
-    String currentDate = openWeatherApiClient.checkDateAndAddCounter();
-
-    Assertions.assertEquals(currentDate, "24/07/2024");
-    System.out.println(currentDate);
   }
 }

--- a/condition-checker/src/test/java/com/mersey/rowing/club/condition_checker/applicationTests/controller/openWeather/OpenWeatherApiClientTests.java
+++ b/condition-checker/src/test/java/com/mersey/rowing/club/condition_checker/applicationTests/controller/openWeather/OpenWeatherApiClientTests.java
@@ -10,11 +10,15 @@ import com.mersey.rowing.club.condition_checker.model.StatusCodeObject;
 import com.mersey.rowing.club.condition_checker.model.openweatherapi.OpenWeatherResponse;
 import com.mersey.rowing.club.condition_checker.utils.TestOpenWeatherUtils;
 import org.json.JSONException;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.skyscreamer.jsonassert.JSONAssert;
 import org.skyscreamer.jsonassert.JSONCompareMode;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
+
+import java.io.IOException;
+import java.text.ParseException;
 
 public class OpenWeatherApiClientTests extends WireMockSpecificDtBaseTests {
 
@@ -46,5 +50,14 @@ public class OpenWeatherApiClientTests extends WireMockSpecificDtBaseTests {
 
     assertThat(statusCodeObject)
         .isEqualTo(openWeatherApiClient.getOpenWeatherAPIResponse(1720626363L));
+  }
+
+  //Placeholder Test
+  @Test
+  void checkDateAndAddCounter() throws IOException {
+    String currentDate = openWeatherApiClient.checkDateAndAddCounter();
+
+    Assertions.assertEquals(currentDate, "24/07/2024");
+    System.out.println(currentDate);
   }
 }


### PR DESCRIPTION
# Description
## What was done this PR?
- DateTimeFormatter was added to OpenWeatherApiClient
- Added a counter.txt file
- checkDateAndAddCounter method was added. This compares the date in counter.txt to the currentDate and adjust the counter accordingly or resets it to 1.
- Added logs to show how many API calls for the currentDate remain. Also an if-statement to warn if there are less than 100 days left.
- Added some Readme info

### Checklist 
- [ ] Ran all tests?
- [ ] Added new test coverage? 

### Tests
**Calling the API increases the counter by +6 (This is due to needing three calls for two separate dates)**
counter.txt original
![image](https://github.com/user-attachments/assets/abd728b8-c5eb-49cb-9a05-825dbc967b96)
counter.txt after API call
![image](https://github.com/user-attachments/assets/c8bbd779-8c8c-4645-9ece-9ffb20907b9d)

**If dates don't match, counter is reset to 6 and date is updated**
counter.txt original
![image](https://github.com/user-attachments/assets/8a5a2d6e-5bb1-4ef5-8aa1-f83120d63c87)
counter.txt after API call
![image](https://github.com/user-attachments/assets/97b7f773-79d5-4f10-aafb-cab724603392)

**If counter is on 899 and API is called, log message should be returned warning of how many calls left for current day**
counter.txt original
![image](https://github.com/user-attachments/assets/78a9af38-0b2d-4e12-a4bb-55d3e6270472)
counter.txt after API call
![image](https://github.com/user-attachments/assets/334efa29-ca50-4451-a592-c5062868a729)
logged message
![image](https://github.com/user-attachments/assets/68952a17-545a-4f62-9215-626792eed5ca)

**IF counter is on 997 and API is called, log message should be returned warning that no calls are left for current day**
counter.txt orginal
![image](https://github.com/user-attachments/assets/006d0d75-3f28-452c-81c2-0dd12a999d7e)
counter.txt after API call
![image](https://github.com/user-attachments/assets/e16c5fc9-77e2-4a94-b755-182f59e00ac8)
logged messages
![image](https://github.com/user-attachments/assets/4ad1f12b-74f4-4936-9956-ffc4c1cf9d5f)
Currently this does not stop calls being made over the 1000 mark, this will be addressed in a later ticket.

**If counter.txt file is empty, then information is entered once the API is called**
counter.txt original
![image](https://github.com/user-attachments/assets/f0ec267b-26ac-4c30-b71d-4c5d62aa1906)
counter.txt after API call
![image](https://github.com/user-attachments/assets/94049b3b-79eb-47c6-be6f-ab447c3cdb19)
logged messages
![image](https://github.com/user-attachments/assets/f5c42a05-6c48-4f16-b494-cc3d70529550)

**If counter.txt file does not exist, then it is created and content updated**
counter.txt does not exist
![image](https://github.com/user-attachments/assets/18dff4fa-de3c-4fd6-8a5a-e6e7b3a6dca2)
counter.txt is created
![image](https://github.com/user-attachments/assets/f0bce1da-ce7d-4f34-a3bf-3796f5a8aac0)
![image](https://github.com/user-attachments/assets/5debefdb-89ce-49e7-b29c-a66be7be83a1)
log message
![image](https://github.com/user-attachments/assets/41c96fef-cae1-4d48-a767-579bfa645f65)







### Any other info 